### PR TITLE
Use a path instead of a string for `callCabal2nix`

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -112,7 +112,7 @@ in {
       ## FIXME: This is failing on some downstream packages when we use
       ##       `checkedDrv` (which adds `-u`, among other things).
         pkgs.shellchecked
-        ((hpkgs.callCabal2nix name "${builtins.dirOf cabalProject}/${path}" {})
+        ((hpkgs.callCabal2nix name (builtins.dirOf cabalProject + "/${path}") {})
           .overrideAttrs
         overrides))
     (parseCabalProject cabalProject);


### PR DESCRIPTION
This should filter out the other packages, speeding up Nix builds.